### PR TITLE
Fix python relative import

### DIFF
--- a/ProG/pre_train.py
+++ b/ProG/pre_train.py
@@ -6,8 +6,8 @@ from torch_geometric.data import Data
 from random import shuffle
 import random
 
-from prompt import GNN
-from utils import gen_ran_output,load_data4pretrain,mkdir, graph_views
+from .prompt import GNN
+from .utils import gen_ran_output,load_data4pretrain,mkdir, graph_views
 
 class GraphCL(torch.nn.Module):
 

--- a/ProG/prompt.py
+++ b/ProG/prompt.py
@@ -2,7 +2,7 @@ import torch
 import torch.nn.functional as F
 from torch_geometric.nn import GCNConv, global_mean_pool, GATConv, TransformerConv
 from torch_geometric.data import Batch, Data
-from utils import act
+from .utils import act
 import warnings
 from deprecated.sphinx import deprecated
 


### PR DESCRIPTION
When I directly run meta_demo.py, I encounter import issues, specifically occurring in prompt.py with following files.

```
in prompt.py
utils import act -> .utils import act
```
```
in pre_train.py
from prompt import GNN -> from .prompt import GNN
from utils import gen_ran_output,load_data4pretrain,mkdir, graph_views -> from .utils import gen_ran_output,load_data4pretrain,mkdir, graph_views
```