### PR TITLE
修复一系列导致无法正常运行pre_train.py的BUG

### DIFF
--- a/pre_train.py
+++ b/pre_train.py
@@ -8,15 +8,15 @@ seed_everything(args.seed)
 
 
 if args.pretrain_task == 'SimGRACE':
-    pt = SimGRACE(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
+    pt = SimGRACE(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device, num_workers=args.num_workers)
 if args.pretrain_task == 'GraphCL':
-    pt = GraphCL(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
+    pt = GraphCL(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device, num_workers=args.num_workers)
 if args.pretrain_task == 'Edgepred_GPPT':
-    pt = Edgepred_GPPT(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
+    pt = Edgepred_GPPT(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device, num_workers=args.num_workers)
 if args.pretrain_task == 'Edgepred_Gprompt':
-    pt = Edgepred_Gprompt(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
+    pt = Edgepred_Gprompt(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device, num_workers=args.num_workers)
 if args.pretrain_task == 'DGI':
-    pt = DGI(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
+    pt = DGI(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device, num_workers=args.num_workers)
 if args.pretrain_task == 'NodeMultiGprompt':
     nonlinearity = 'prelu'
     pt = NodePrePrompt(args.dataset_name, args.hid_dim, nonlinearity, 0.9, 0.9, 0.1, 0.001, 1, 0.3, device=args.device)
@@ -25,6 +25,6 @@ if args.pretrain_task == 'GraphMultiGprompt':
     pt = GraphPrePrompt(graph_list, input_dim, out_dim, args.dataset_name, args.hid_dim, nonlinearity,0.9,0.9,0.1,1,0.3, device=args.device)
 if args.pretrain_task == 'GraphMAE':
     pt = GraphMAE(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device,
-                  mask_rate=0.75, drop_edge_rate=0.0, replace_rate=0.1, loss_fn='sce', alpha_l=2)
+                  mask_rate=0.75, drop_edge_rate=0.0, replace_rate=0.1, loss_fn='sce', alpha_l=2, num_workers=args.num_workers)
 pt.pretrain()
 

--- a/pre_train.py
+++ b/pre_train.py
@@ -7,23 +7,23 @@ args = get_args()
 seed_everything(args.seed)
 
 
-if args.task == 'SimGRACE':
+if args.pretrain_task == 'SimGRACE':
     pt = SimGRACE(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
-if args.task == 'GraphCL':
+if args.pretrain_task == 'GraphCL':
     pt = GraphCL(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
-if args.task == 'Edgepred_GPPT':
+if args.pretrain_task == 'Edgepred_GPPT':
     pt = Edgepred_GPPT(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
-if args.task == 'Edgepred_Gprompt':
+if args.pretrain_task == 'Edgepred_Gprompt':
     pt = Edgepred_Gprompt(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
-if args.task == 'DGI':
+if args.pretrain_task == 'DGI':
     pt = DGI(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device)
-if args.task == 'NodeMultiGprompt':
+if args.pretrain_task == 'NodeMultiGprompt':
     nonlinearity = 'prelu'
-    pt = NodePrePrompt(args.dataset_name, args.hid_dim, nonlinearity, 0.9, 0.9, 0.1, 0.001, 1, 0.3)
-if args.task == 'GraphMultiGprompt':
+    pt = NodePrePrompt(args.dataset_name, args.hid_dim, nonlinearity, 0.9, 0.9, 0.1, 0.001, 1, 0.3, device=args.device)
+if args.pretrain_task == 'GraphMultiGprompt':
     nonlinearity = 'prelu'
-    pt = GraphPrePrompt(graph_list, input_dim, out_dim, args.dataset_name, args.hid_dim, nonlinearity,0.9,0.9,0.1,1,0.3)
-if args.task == 'GraphMAE':
+    pt = GraphPrePrompt(graph_list, input_dim, out_dim, args.dataset_name, args.hid_dim, nonlinearity,0.9,0.9,0.1,1,0.3, device=args.device)
+if args.pretrain_task == 'GraphMAE':
     pt = GraphMAE(dataset_name = args.dataset_name, gnn_type = args.gnn_type, hid_dim = args.hid_dim, gln = args.num_layer, num_epoch=args.epochs, device=args.device,
                   mask_rate=0.75, drop_edge_rate=0.0, replace_rate=0.1, loss_fn='sce', alpha_l=2)
 pt.pretrain()

--- a/prompt_graph/pretrain/DGI.py
+++ b/prompt_graph/pretrain/DGI.py
@@ -112,7 +112,7 @@ class DGI(PreTrain):
             self.input_dim = input_dim
 
             from torch_geometric import loader
-            self.batch_dataloader = loader.DataLoader(graph_list,batch_size=512,shuffle=False)
+            self.batch_dataloader = loader.DataLoader(graph_list,batch_size=512,shuffle=False, num_workers=self.num_workers)
 
             data = graph_list
 

--- a/prompt_graph/pretrain/Edgepred_GPPT.py
+++ b/prompt_graph/pretrain/Edgepred_GPPT.py
@@ -23,9 +23,9 @@ class Edgepred_GPPT(PreTrain):
             edge_index = edge_index.transpose(0, 1)
             data = TensorDataset(edge_label, edge_index)
             if self.dataset_name in['ogbn-arxiv', 'Flickr']:
-                return DataLoader(data, batch_size = 1024, shuffle=True)
+                return DataLoader(data, batch_size = 1024, shuffle=True, num_workers=self.num_workers)
             else:
-                return DataLoader(data, batch_size=64, shuffle=True)
+                return DataLoader(data, batch_size=64, shuffle=True, num_workers=self.num_workers)
         
         elif self.dataset_name in ['MUTAG', 'ENZYMES', 'COLLAB', 'PROTEINS', 'IMDB-BINARY', 'REDDIT-BINARY', 'COX2', 'BZR', 'PTC_MR', 'ogbg-ppa', 'DD']:
             self.data, edge_label, edge_index, self.input_dim, self.output_dim = load4link_prediction_multi_graph(self.dataset_name)
@@ -35,10 +35,10 @@ class Edgepred_GPPT(PreTrain):
             
             # Batch图太大，向前传播的时候分开操作
             if self.dataset_name in ['COLLAB', 'IMDB-BINARY', 'REDDIT-BINARY', 'ogbg-ppa', 'DD']:
-                self.batch_dataloader = DataLoader(self.data.to_data_list(),batch_size=256,shuffle=False)
-                return DataLoader(data, batch_size=512000, shuffle=True)
+                self.batch_dataloader = DataLoader(self.data.to_data_list(),batch_size=256,shuffle=False, num_workers=self.num_workers)
+                return DataLoader(data, batch_size=512000, shuffle=True, num_workers=self.num_workers)
 
-            return DataLoader(data, batch_size=64, shuffle=True)
+            return DataLoader(data, batch_size=64, shuffle=True, num_workers=self.num_workers)
       
     def pretrain_one_epoch(self):
 

--- a/prompt_graph/pretrain/Edgepred_Gprompt.py
+++ b/prompt_graph/pretrain/Edgepred_Gprompt.py
@@ -22,9 +22,9 @@ class Edgepred_Gprompt(PreTrain):
             self.adj = edge_index_to_sparse_matrix(self.data.edge_index, self.data.x.shape[0]).to(self.device)
             data = prepare_structured_data(self.data)
             if self.dataset_name in['ogbn-arxiv', 'Flickr']:
-                return DataLoader(TensorDataset(data), batch_size = 1024, shuffle=True)
+                return DataLoader(TensorDataset(data), batch_size = 1024, shuffle=True, num_workers=self.num_workers)
             else:
-                return DataLoader(TensorDataset(data), batch_size=64, shuffle=True)
+                return DataLoader(TensorDataset(data), batch_size=64, shuffle=True, num_workers=self.num_workers)
         
         elif self.dataset_name in ['MUTAG', 'ENZYMES', 'COLLAB', 'PROTEINS', 'IMDB-BINARY', 'REDDIT-BINARY', 'COX2', 'BZR', 'PTC_MR', 'ogbg-ppa', 'DD']:
             self.data, edge_label, edge_index, self.input_dim, self.output_dim = load4link_prediction_multi_graph(self.dataset_name)          
@@ -33,10 +33,10 @@ class Edgepred_Gprompt(PreTrain):
 
             if self.dataset_name in  ['COLLAB', 'IMDB-BINARY', 'REDDIT-BINARY', 'ogbg-ppa', 'DD']:
                 from torch_geometric import loader
-                self.batch_dataloader = loader.DataLoader(self.data.to_data_list(),batch_size=256,shuffle=False)
-                return DataLoader(TensorDataset(data), batch_size=5120000, shuffle=True)
+                self.batch_dataloader = loader.DataLoader(self.data.to_data_list(),batch_size=256,shuffle=False, num_workers=self.num_workers)
+                return DataLoader(TensorDataset(data), batch_size=5120000, shuffle=True, num_workers=self.num_workers)
             else:
-                return DataLoader(TensorDataset(data), batch_size=64, shuffle=True)
+                return DataLoader(TensorDataset(data), batch_size=64, shuffle=True, num_workers=self.num_workers)
     
     def pretrain_one_epoch(self):
         accum_loss, total_step = 0, 0

--- a/prompt_graph/pretrain/GraphCL.py
+++ b/prompt_graph/pretrain/GraphCL.py
@@ -54,9 +54,9 @@ class GraphCL(PreTrain):
             view_list_2.append(view_g)
 
         loader1 = DataLoader(view_list_1, batch_size=batch_size, shuffle=False,
-                                num_workers=1)  # you must set shuffle=False !
+                                num_workers=self.num_workers)  # you must set shuffle=False !
         loader2 = DataLoader(view_list_2, batch_size=batch_size, shuffle=False,
-                                num_workers=1)  # you must set shuffle=False !
+                                num_workers=self.num_workers)  # you must set shuffle=False !
 
         return loader1, loader2
     

--- a/prompt_graph/pretrain/GraphMAE.py
+++ b/prompt_graph/pretrain/GraphMAE.py
@@ -199,16 +199,22 @@ class GraphMAE(PreTrain):
     def load_graph_data(self):
 
         if self.dataset_name in ['PubMed', 'CiteSeer', 'Cora','Computers', 'Photo', 'Reddit', 'WikiCS', 'Flickr', 'ogbn-arxiv', 'Actor', 'Texas', 'Wisconsin']:
-            graph_list, in_node_feat_dim = NodePretrain(dataname = self.dataset_name, num_parts=200)
+            data, in_node_feat_dim, _ = load4node(self.dataset_name)  # 需要先读入数据，参数为dataset_name，为str格式
+            graph_list = NodePretrain(
+                data=data,
+                num_parts=200,
+                split_method='Cluster'
+                )  # NodePretrain 没有dataname参数，此处应为pyG的data类型
+            # graph_list, in_node_feat_dim = NodePretrain(dataname = self.dataset_name, num_parts=200)
             # data = Batch.from_data_list(graph_list)
         elif self.dataset_name in ['MUTAG', 'ENZYMES', 'COLLAB', 'PROTEINS', 'IMDB-BINARY', 'REDDIT-BINARY', 'COX2', 'BZR', 'PTC_MR', 'ogbg-ppa', 'DD']:
             in_node_feat_dim, _, graph_list= load4graph(self.dataset_name,pretrained=True)
             # data = Batch.from_data_list()
         self.input_dim = in_node_feat_dim
         if self.dataset_name == 'ogbg-ppa':
-             return DataLoader(graph_list, batch_size=256, shuffle=True)
+             return DataLoader(graph_list, batch_size=256, shuffle=True, num_workers=self.num_workers)
         else:
-            return DataLoader(graph_list, batch_size=64, shuffle=True)
+            return DataLoader(graph_list, batch_size=64, shuffle=True, num_workers=self.num_workers)
     
     def pretrain(self):
         from torchmetrics import MeanMetric

--- a/prompt_graph/pretrain/SimGRACE.py
+++ b/prompt_graph/pretrain/SimGRACE.py
@@ -22,7 +22,13 @@ class SimGRACE(PreTrain):
         
     def load_graph_data(self):
         if self.dataset_name in ['PubMed', 'CiteSeer', 'Cora','Computers', 'Photo', 'Reddit', 'WikiCS', 'Flickr','ogbn-arxiv', 'Actor', 'Texas', 'Wisconsin']:
-            self.graph_list, self.input_dim = NodePretrain(dataname = self.dataset_name, num_parts=200)
+            data, self.input_dim, _ = load4node(self.dataset_name)  # 需要先读入数据，参数为dataset_name，为str格式
+            self.graph_list = NodePretrain(
+                data=data,
+                num_parts=200,
+                split_method='Cluster'
+                )  # NodePretrain 没有dataname参数，此处应为pyG的data类型
+            # self.graph_list, self.input_dim = NodePretrain(dataname = self.dataset_name, num_parts=200)
         else:
             self.input_dim, self.out_dim, self.graph_list= load4graph(self.dataset_name,pretrained=True)
         
@@ -32,7 +38,7 @@ class SimGRACE(PreTrain):
             raise KeyError(
                 "batch_size {} makes the last batch only contain 1 graph, \n which will trigger a zero bug in SimGRACE!")
 
-        loader = DataLoader(graph_list, batch_size=batch_size, shuffle=False, num_workers=1)
+        loader = DataLoader(graph_list, batch_size=batch_size, shuffle=False, num_workers=self.num_workers)
         return loader
     
     def forward_cl(self, x, edge_index, batch):

--- a/prompt_graph/pretrain/base.py
+++ b/prompt_graph/pretrain/base.py
@@ -3,7 +3,7 @@ from prompt_graph.model import GAT, GCN, GCov, GIN, GraphSAGE, GraphTransformer
 from torch.optim import Adam
 
 class PreTrain(torch.nn.Module):
-    def __init__(self, gnn_type='TransformerConv', dataset_name = 'Cora', input_dim=128, hid_dim = 128, gln = 2, num_epoch = 1000, device : int = 5, graph_list=None):
+    def __init__(self, gnn_type='TransformerConv', dataset_name = 'Cora', input_dim=128, hid_dim = 128, gln = 2, num_epoch = 1000, device : int = 5, graph_list=None, num_workers=0):
         super().__init__()
         self.device = torch.device('cuda:' + str(device) if torch.cuda.is_available() else 'cpu')
         self.graph_list = graph_list
@@ -15,6 +15,7 @@ class PreTrain(torch.nn.Module):
         self.hid_dim =hid_dim
         self.learning_rate = 0.001
         self.weight_decay = 0.00005
+        self.num_workers = num_workers
     
     def initialize_gnn(self, input_dim, hid_dim):
         if self.gnn_type == 'GAT':


### PR DESCRIPTION
修复一系列无法正常运行pre_train.py的BUG：
- 修复pre_train.py中，pretrain_task参数名不匹配的错误
- 修复SimGRACE在初始化NodePretrain时dataname参数的错误
- 在PreTrain中接受num_workers参数，并在子类初始化Dataloader时使用
- 修复GraphPrePrompt、NodePrePrompt无法正确识别device的错误